### PR TITLE
adding Dockerfiles for building cpu and gpu images

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -1,0 +1,23 @@
+# See all tag variants at https://hub.docker.com/r/tensorflow/tensorflow/tags/
+# build with `ln -sf Dockerfile.cpu Dockerfile && docker build --network=host -t {container-name} .`
+FROM tensorflow/tensorflow:latest-py3-jupyter
+
+## modify below
+ARG username=gdl
+ARG groupid=1000
+ARG userid=1000
+## end modify
+
+COPY ./requirements.txt /
+RUN python3 -m pip install --upgrade pip
+RUN pip install -r /requirements.txt
+
+# -m option creates a fake writable home folder for Jupyter.
+RUN groupadd -g $groupid $username \
+    && useradd -m -r -u $userid -g $username $username
+USER $username
+
+VOLUME ["/GDL"]
+WORKDIR /GDL
+
+CMD ["jupyter", "notebook", "--no-browser", "--ip=0.0.0.0", "/GDL"]

--- a/Dockerfile.gpu
+++ b/Dockerfile.gpu
@@ -1,0 +1,25 @@
+# See all tag variants at https://hub.docker.com/r/tensorflow/tensorflow/tags/
+# build with `ln -sf Dockerfile.gpu Dockerfile && docker build --network=host -t {container-name} .`
+# NOTE(jwd) - if you wish to use this implementation, you must install nvidia-docker v2.0
+# see https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0) for steps
+FROM tensorflow/tensorflow:latest-gpu-py3-jupyter
+
+## modify below
+ARG username=gdl
+ARG groupid=1000
+ARG userid=1000
+## end modify
+
+COPY ./requirements.txt /
+RUN python3 -m pip install --upgrade pip
+RUN pip install -r /requirements.txt
+
+# -m option creates a fake writable home folder for Jupyter.
+RUN groupadd -g $groupid $username \
+    && useradd -m -r -u $userid -g $username $username
+USER $username
+
+VOLUME ["/GDL"]
+WORKDIR /GDL
+
+CMD ["jupyter", "notebook", "--no-browser", "--ip=0.0.0.0", "/GDL"]

--- a/launch-docker-cpu.sh
+++ b/launch-docker-cpu.sh
@@ -1,0 +1,2 @@
+# USAGE - ./launch-docker-cpu.sh {abs-path-to-GDL-code}
+docker run --rm --network=host -it -v $1:/GDL gdl-image-cpu

--- a/launch-docker-gpu.sh
+++ b/launch-docker-gpu.sh
@@ -1,0 +1,2 @@
+# USAGE - ./launch-docker-gpu.sh {abs-path-to-GDL-code}
+docker run --rm --runtime=nvidia --network=host -it -v $1:/GDL gdl-image


### PR DESCRIPTION
Thanks for the awesome book!  I am really enjoying reading it (just starting Chapter 3).

I use docker for most everything dl-related so I thought that I would share some Dockerfiles for setting up cpu and gpu environments for following along with the book.  The images are built using base images from  [tensorflow's docker hub](https://hub.docker.com/r/tensorflow/tensorflow).

Note: if the user wishes to use the `Dockerfile.gpu` implementation, that user will need to [`nvidia-docker` v2](https://github.com/nvidia/nvidia-docker/wiki/Installation-(version-2.0)).  This link is provided in the `Dockerfile.gpu` as well for reference.