### PR TITLE
Fix file name error caused by different RUN_ID

### DIFF
--- a/07_05_musegan_analysis.ipynb
+++ b/07_05_musegan_analysis.ipynb
@@ -37,7 +37,7 @@
    "source": [
     "# run params\n",
     "SECTION = 'compose'\n",
-    "RUN_ID = '0016'\n",
+    "RUN_ID = '0017'\n",
     "DATA_NAME = 'chorales'\n",
     "FILENAME = 'Jsb16thSeparated.npz'\n",
     "RUN_FOLDER = 'run/{}/'.format(SECTION)\n",


### PR DESCRIPTION
Fix file name error caused by different RUN_ID.

Fixes #37.