### PR TITLE
Replaces glob() Function With os.walk()

### DIFF
--- a/03_05_vae_faces_train.ipynb
+++ b/03_05_vae_faces_train.ipynb
@@ -21,7 +21,6 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "from glob import glob\n",
     "import numpy as np\n",
     "\n",
     "from models.VAE import VariationalAutoencoder\n",
@@ -69,7 +68,12 @@
     "INPUT_DIM = (128,128,3)\n",
     "BATCH_SIZE = 32\n",
     "\n",
-    "filenames = np.array(glob(os.path.join(DATA_FOLDER, '*/*.jpg')))\n",
+    "filenames = []\n",
+    "\n",
+    "for root, dirs, files in os.walk(DATA_FOLDER):\n",
+    "    for file in files:\n",
+    "        if file.endswith(\".jpg\"):\n",
+    "            filenames.append(os.path.join(root, file))\n",
     "\n",
     "NUM_IMAGES = len(filenames)"
    ]


### PR DESCRIPTION
Implementation of the glob() function varies between python versions
and is unable to reliably locate all of the .jpg data files in the
celeb dataset. It has been replaced with the os.walk() function.