### PR TITLE
fix: typo in 06_01_lstm_text_train.ipynb

### DIFF
--- a/06_01_lstm_text_train.ipynb
+++ b/06_01_lstm_text_train.ipynb
@@ -324,7 +324,7 @@
     "    \n",
     "    \n",
     "if train_model:\n",
-    "    epochs = 1000\n",
+    "    epochs = 100\n",
     "    batch_size = 32\n",
     "    num_batches = int(len(X) / batch_size)\n",
     "    callback = LambdaCallback(on_epoch_end=on_epoch_end)\n",


### PR DESCRIPTION
This looks like a typo. The book also sets `epochs = 100` :)