### PR TITLE
Tweaks the missing `git` installation.

### DIFF
--- a/Dockerfile.cpu
+++ b/Dockerfile.cpu
@@ -12,7 +12,8 @@ ARG userid=1000
 
 RUN apt-get update && apt-get install -y \
     graphviz \
-    libgraphviz-dev
+    libgraphviz-dev \
+    git
 
 COPY ./requirements.txt /
 RUN python3 -m pip install --upgrade pip


### PR DESCRIPTION
In requirements.txt, there is a git dependency such as ``git+https://www.github.com/keras-team/keras-contrib.git``, where the ``docker build`` is failed due to the absence of ``git`` installation.