### PR TITLE
changing pillows version to 6.2.2 to help with the installation

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -53,7 +53,7 @@ pandocfilters==1.4.2
 parso==0.5.1
 pexpect==4.7.0
 pickleshare==0.7.5
-Pillow==6.2.0
+Pillow==6.2.2
 prometheus-client==0.7.1
 prompt-toolkit==2.0.10
 protobuf==3.10.0


### PR DESCRIPTION
My pip install -r requirements.txt failed until I changed the pillows version. Thanks, and excited to read your book!